### PR TITLE
Adds support for future years in the year dropdown

### DIFF
--- a/chrome_extension/src/components/form-views/generate-password-view.tsx
+++ b/chrome_extension/src/components/form-views/generate-password-view.tsx
@@ -34,6 +34,7 @@ import PasswordToast from "@app/components/ui/password-toast";
 import MuiSelect from "@app/components/select/MuiSelect";
 import cn from "classnames";
 import Logo from "../ui/logo";
+import { useYearOptions } from "@app/lib/hooks/use-year-options";
 
 export default function GeneratePasswordView() {
   const { openModal } = useModal();
@@ -49,6 +50,7 @@ export default function GeneratePasswordView() {
     date: moment(Date.now()).format("YYYY"),
     retries: "0",
   });
+  const yearOptions = useYearOptions();
 
   const handleGeneratePassword = async () => {
     await hmacSha256(generatePswState).then((passwordhash) => {
@@ -64,7 +66,6 @@ export default function GeneratePasswordView() {
       />
     );
   };
-
 
   const isFormFieldsValid =
     !isEmptyString(generatePswState.host) &&
@@ -233,7 +234,7 @@ export default function GeneratePasswordView() {
       </div>
       <MuiSelect
         className="w-full mb-4"
-        options={["2022", "2023", "2024"]}
+        options={yearOptions}
         onChange={handleDate}
         value={generatePswState.date}
       />

--- a/chrome_extension/src/lib/hooks/use-year-options.ts
+++ b/chrome_extension/src/lib/hooks/use-year-options.ts
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+
+export const useYearOptions = (startYear = 2022, futureBuffer = 2) => {
+  const currentYear = new Date().getFullYear();
+
+  return useMemo(() => {
+    const options: string[] = [];
+    for (let year = startYear; year <= currentYear + futureBuffer; year++) {
+      options.push(year.toString());
+    }
+    return options;
+  }, [startYear, futureBuffer, currentYear]);
+};

--- a/web/src/components/form-views/generate-password-view.tsx
+++ b/web/src/components/form-views/generate-password-view.tsx
@@ -31,6 +31,7 @@ import TextFieldErrorList from "@app/components/textfield-error-list";
 import moment from "moment";
 import PasswordToast from "@app/components/ui/password-toast";
 import MuiSelect from "@app/components/select/MuiSelect";
+import { useYearOptions } from "@app/lib/hooks/use-year-options";
 
 export default function GeneratePasswordView() {
   const { openModal } = useModal();
@@ -46,6 +47,7 @@ export default function GeneratePasswordView() {
     date: moment(Date.now()).format("YYYY"),
     retries: 0,
   });
+  const yearOptions = useYearOptions();
 
   const handleGeneratePassword = async () => {
     await hmacSha256(generatePswState).then((passwordhash) => {
@@ -256,7 +258,7 @@ export default function GeneratePasswordView() {
       </div>
       <MuiSelect
         className="w-full mb-4"
-        options={["2022", "2023", "2024"]}
+        options={yearOptions}
         onChange={handleDate}
         value={generatePswState.date}
       />

--- a/web/src/lib/hooks/use-year-options.ts
+++ b/web/src/lib/hooks/use-year-options.ts
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+
+export const useYearOptions = (startYear = 2022, futureBuffer = 2) => {
+  const currentYear = new Date().getFullYear();
+
+  return useMemo(() => {
+    const options: string[] = [];
+    for (let year = startYear; year <= currentYear + futureBuffer; year++) {
+      options.push(year.toString());
+    }
+    return options;
+  }, [startYear, futureBuffer, currentYear]);
+};


### PR DESCRIPTION
## Overview
Adds support for future years in the year dropdown. This dynamically generates year options from a configurable start year up to the current year + a buffer (default: 2 years).
Replaces hardcoded years in generate-password form.

## Changes
- New hook: `hooks/use-year-options.ts` (params: `startYear=2022`, `futureBuffer=2`;).
- Updated `MuiSelect` to use hook's `yearOptions`.

Before:
<img width="938" height="1136" alt="image" src="https://github.com/user-attachments/assets/aa8a5568-b273-40f8-8ccc-5b0ac280684c" />

After:
<img width="982" height="1326" alt="image" src="https://github.com/user-attachments/assets/14e8ddff-5d02-4f1b-bdef-e12a71fe9067" />


@spannercode @kneerose